### PR TITLE
치지직의 CSS Modules 클래스명 변경으로 채널 탭에 라이브 채팅 버튼이 표시되지 않는 문제를 수정합니다.

### DIFF
--- a/web/inject.js
+++ b/web/inject.js
@@ -707,7 +707,7 @@
         path.startsWith("/video/")
       ) {
         return attachVodObserver(node);
-      } else if (node.className.startsWith?.("channel_")) {
+      } else if (node.className.startsWith?.("channel_") || path.split("/").length === 2) {
         return initChannelFeatures(node);
       }
     };
@@ -745,7 +745,7 @@
   };
 
   const initChannelFeatures = async (node) => {
-    const list = node.querySelector('[class*="channel_area__"]');
+    const list = node.querySelector('[class*="channel_area__"]') || node.querySelector('[role="tablist"]');
     if (list == null) {
       return;
     }


### PR DESCRIPTION
# 문제
치지직이 CSS 클래스명을 CSS Modules 해시 형식(예: `_section_1svxi_8`, `_list_2b57p_2`)으로 변경하면서의존하던 두 개의 selector가 동작하지 않게 되었습니다.

- `node.className.startsWith("channel_")` — 채널 페이지 감지 실패
- `node.querySelector('[class*="channel_area__"]')` — 탭 목록 요소를 찾지 못함

그 결과 `initChannelFeatures`가 호출되지 않아 라이브 채팅 버튼이 추가되지 않았습니다.

# 변경사항
- 채널 페이지 감지 조건에 `path.split("/").length === 2` fallback 추가 — 기존에 `live_`, `vod_` 클래스명 변경 시 수정한 방식과 동일한 패턴
- 채널 탭 목록 selector에 `node.querySelector('[role="tablist"]')` fallback 추가

# 테스트
수정 후 채널 탭에 라이브 채팅 버튼이 정상적으로 표시되는 것을 확인했습니다.