### PR TITLE
fix: 채널 페이지 외의 경로에서 채팅 버튼이 노출되는 문제 수정

### DIFF
--- a/web/inject.js
+++ b/web/inject.js
@@ -697,6 +697,15 @@
       }
       hidePreview();
       const path = location.pathname;
+      const extractUid = (node) => {
+        const anchor = node.querySelector('a[href*="profile/"]');
+        if (!anchor) return null;
+        const href = anchor.getAttribute('href');
+        const match = href.match(/profile\/([a-f0-9]+)/);
+        return match ? match[1] : null;
+      };
+
+      const uid = extractUid(node);
       if (
         node.className.startsWith?.("live_") ||
         (path.startsWith("/live/") && node.querySelector("aside"))
@@ -707,7 +716,7 @@
         path.startsWith("/video/")
       ) {
         return attachVodObserver(node);
-      } else if (node.className.startsWith?.("channel_") || path.split("/").length === 2) {
+      } else if (node.className.startsWith?.("channel_") || (path.split("/").length === 2 && uid === path.split("/")[1])) {
         return initChannelFeatures(node);
       }
     };


### PR DESCRIPTION
- 특정 채널 페이지(/uid)에서만 채팅 버튼이 나타나도록 조건 강화
- node 내에서 UID를 추출하는 로직 추가
- 기존 경로(/live/, /video/) 외에 채널 경로 판단 시 UID 일치 여부를 확인하여 불필요한 노출 방지